### PR TITLE
bump package edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "snip1155-reference-impl"
 version = "0.2.1"
 authors = ["DDT5"]
-edition = "2018"
+edition = "2021"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.


### PR DESCRIPTION
This fixes the issue with `getrandom` being included in the wasm32 build.

Looking at these lines:
https://github.com/scrtlabs/cosmwasm/blob/6c639b5a85ef66f87d72284dc68ae051eab09007/packages/std/Cargo.toml#L62-L63

I think the `not` operator was not supported in the 2018 version, which caused `secret-cosmwasm-crypto` to be included. It has a dependency on `getrandom` which doesn't compile to wasm without the "js" feature, but that feature is not compatible on-chain. 

```
secret-cosmwasm-crypto v1.1.10 [only supposed to be included when 'not(target_arch = "wasm32")']
│   │   ├── digest v0.10.7
│   │   │   ├── block-buffer v0.10.4
│   │   │   │   └── generic-array v0.14.7
│   │   │   │       └── typenum v1.16.0
│   │   │   │       [build-dependencies]
│   │   │   │       └── version_check v0.9.4
│   │   │   ├── crypto-common v0.1.6
│   │   │   │   ├── generic-array v0.14.7 (*)
│   │   │   │   └── typenum v1.16.0
│   │   │   └── subtle v2.5.0
│   │   ├── ed25519-zebra v3.1.0
│   │   │   ├── curve25519-dalek v3.2.0
│   │   │   │   ├── byteorder v1.4.3
│   │   │   │   ├── digest v0.9.0
│   │   │   │   │   └── generic-array v0.14.7 (*)
│   │   │   │   ├── rand_core v0.5.1
│   │   │   │   ├── subtle v2.5.0
│   │   │   │   └── zeroize v1.6.0
│   │   │   ├── hashbrown v0.12.3
│   │   │   │   └── ahash v0.7.6
│   │   │   │       ├── getrandom v0.2.10 [here is the offender]
│   │   │   │       │   ├── cfg-if v1.0.0
│   │   │   │       │   └── libc v0.2.147
│   │   │   │       └── once_cell v1.18.0
│   │   │   │       [build-dependencies]
│   │   │   │       └── version_check v0.9.4
│   │   │   ├── hex v0.4.3
│   │   │   ├── rand_core v0.6.4
│   │   │   │   └── getrandom v0.2.10 (*)
│   │   │   ├── serde v1.0.188 (*)
│   │   │   ├── sha2 v0.9.9
│   │   │   │   ├── block-buffer v0.9.0
│   │   │   │   │   └── generic-array v0.14.7 (*)
│   │   │   │   ├── cfg-if v1.0.0
│   │   │   │   ├── cpufeatures v0.2.9
│   │   │   │   ├── digest v0.9.0 (*)
│   │   │   │   └── opaque-debug v0.3.0
│   │   │   └── zeroize v1.6.0
```